### PR TITLE
Fix markdownlint compliance in compatibility policy

### DIFF
--- a/docs/policies/compatibility.md
+++ b/docs/policies/compatibility.md
@@ -25,6 +25,7 @@ A combined assurance run is considered **supported** when:
 This matrix records combinations of tool versions that have been validated together.
 
 ### Legend
+
 - **Test level:** Smoke = install + basic invocation; Partial = key profiles; Full = suite + TSPP AL checks + evidence bundle
 - **Evidence:** link to CI run / artifact bundle / release tag notes
 


### PR DESCRIPTION
Add required blank lines around the ### Legend heading to satisfy MD022

Surround the legend list with blank lines to satisfy MD032

Keep compatibility matrix content unchanged while restoring CI green status