### PR TITLE
fix: close v1.10.0 release integrity gaps

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install jsonschema
+          pip install jsonschema PyYAML
       - name: Validate examples against schemas
         run: python tools/validate_examples.py
       - name: Regenerate operational stack demo bundle

--- a/RELEASE_NOTES_v1.10.0.md
+++ b/RELEASE_NOTES_v1.10.0.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: "TRQP Assurance Hub v1.10.0"
+nav_exclude: true
+permalink: /RELEASE_NOTES_v1.10.0/
+---
+
 # TRQP Assurance Hub v1.10.0
 
 ## Portfolio integration release

--- a/docs/portfolio-integration.md
+++ b/docs/portfolio-integration.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: "Portfolio Integration"
+nav_exclude: true
+permalink: /docs/portfolio-integration/
+---
+
 # Portfolio Integration
 
 The TRQP Assurance Hub participates in the coordinated TRQP repository set through `portfolio/integration-contract.json`.

--- a/docs/reference/untp-digital-identity-anchor.md
+++ b/docs/reference/untp-digital-identity-anchor.md
@@ -21,7 +21,7 @@ This repository treats DIA as an **anchor extension** to the SAD-1 profile. The 
 - DIA specification: https://untp.unece.org/docs/specification/DigitalIdentityAnchor/
 - DIA JSON-LD context (0.6.1): https://test.uncefact.org/vocabulary/untp/dia/0.6.1/context/
 - Identity Resolver specification: https://untp.unece.org/docs/specification/IdentityResolver/
-- UNTP specification: https://uncefact.github.io/spec-untp/un-transparency-protocol.pdf
+- UNTP technical specifications: https://untp.unece.org/docs/specification/
 
 ## Repository wiring
 

--- a/docs/reference/untp-digital-identity-anchor.md
+++ b/docs/reference/untp-digital-identity-anchor.md
@@ -21,7 +21,7 @@ This repository treats DIA as an **anchor extension** to the SAD-1 profile. The 
 - DIA specification: https://untp.unece.org/docs/specification/DigitalIdentityAnchor/
 - DIA JSON-LD context (0.6.1): https://test.uncefact.org/vocabulary/untp/dia/0.6.1/context/
 - Identity Resolver specification: https://untp.unece.org/docs/specification/IdentityResolver/
-- UNTP specification overview: https://uncefact.github.io/spec-untp/docs/specification/
+- UNTP specification: https://uncefact.github.io/spec-untp/un-transparency-protocol.pdf
 
 ## Repository wiring
 

--- a/scripts/validate_docs_site.py
+++ b/scripts/validate_docs_site.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 EXCLUDED_PREFIXES = (".github/", "vendor/", "node_modules/", "external/")
 errors = []
 public_docs = []
+catalog_required = []
 
 for path in sorted(ROOT.rglob("*.md")):
     rel = path.relative_to(ROOT).as_posix()
@@ -17,8 +18,14 @@ for path in sorted(ROOT.rglob("*.md")):
     text = path.read_text(encoding="utf-8")
     if not text.startswith("---\n"):
         errors.append(f"{rel}: missing Jekyll front matter")
+        front_matter = ""
     elif "\n---\n" not in text[4:]:
         errors.append(f"{rel}: unterminated Jekyll front matter")
+        front_matter = ""
+    else:
+        front_matter = text.split("\n---\n", 1)[0]
+    if not re.search(r"(?mi)^nav_exclude:\s*true\s*$", front_matter):
+        catalog_required.append(rel)
     if text.count("```mermaid") > text.count("```") // 2:
         errors.append(f"{rel}: Mermaid fence appears unterminated")
 
@@ -27,7 +34,7 @@ if not catalog.exists():
     errors.append("documentation.md: missing documentation catalogue")
 else:
     catalog_text = catalog.read_text(encoding="utf-8")
-    for rel in public_docs:
+    for rel in catalog_required:
         if rel in {"documentation.md", "index.md"}:
             continue
         if f"`/{rel}`" not in catalog_text:

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -13,7 +13,7 @@ for md in root.rglob('*.md'):
     text=md.read_text(encoding='utf-8',errors='replace')
     for target in re.findall(r'\[[^\]]+\]\(([^)]+)\)', text):
         t=target.split('#',1)[0].strip()
-        if not t or '://' in t or t.startswith(('mailto:','data:','#')): continue
+        if not t or '://' in t or '{{' in t or '}}' in t or t.startswith(('mailto:','data:','#')): continue
         dest=(md.parent/t).resolve()
         try: dest.relative_to(root.resolve())
         except ValueError: continue


### PR DESCRIPTION
Closes release-integrity issues exposed by the v1.10.0 synchronized portfolio integration release. Makes the new release/integration pages valid Jekyll inputs, honors `nav_exclude` in catalogue validation, prevents rendered Jekyll links from being misclassified as filesystem links, installs PyYAML for document tests, and replaces the stale UNTP overview URL.