### PR TITLE
ci: use current TSPP and CTS versions in manifest dry-run

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,10 +65,10 @@ jobs:
           python tools/generate-manifest.py \
             --build-id "dry-run-check" \
             --target "https://registry.example.org" \
-            --cs-version "1.2.1" \
+            --cs-version "1.7.0" \
             --cs-profile-id "baseline" \
             --cs-run-id "dry-run-run" \
-            --tspp-version "0.10.1" \
+            --tspp-version "0.15.0" \
             --tspp-assurance-level "AL1" \
             --tspp-run-id "dry-run-run" \
             --overall-status "pass" \


### PR DESCRIPTION
Align the quality-workflow manifest-generation smoke test with the synchronized TRQP release train.

### Changed
- `--cs-version`: 1.2.1 -> 1.7.0
- `--tspp-version`: 0.10.1 -> 0.15.0

### Scope
This is a CI/example hygiene correction only. It does not change Hub schemas, aggregation semantics, or the v1.10.0 portfolio integration contract.

### Assurance effect
The smoke test no longer emits an example manifest that teaches stale component relationships while the repository declares the current CTS/TSPP versions elsewhere.