### PR TITLE
feat(stack): establish coordinated TRQP release readiness gate

### DIFF
--- a/.github/workflows/stack-release-eligibility.yml
+++ b/.github/workflows/stack-release-eligibility.yml
@@ -1,0 +1,109 @@
+name: stack-release-eligibility
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'stack/**'
+      - 'tools/stack_*.py'
+      - 'tests/test_stack_release_readiness.py'
+      - 'docs/adoption/**'
+      - 'GOVERNANCE.md'
+      - 'Makefile'
+      - '.github/workflows/stack-release-eligibility.yml'
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  decisive-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Hub candidate
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jsonschema pyyaml pytest pynacl
+
+      - name: Validate release contract and immutable tuple
+        run: make stack-release-check
+
+      - name: Prove clean-room bootstrap
+        run: python tools/stack_bootstrap.py --clean
+
+      - name: Install coordinated component dependencies
+        run: |
+          python -m pip install -r .stack-work/cts/cts/requirements.txt
+          python -m pip install -r .stack-work/tspp/harness/requirements.txt
+
+      - name: Execute declared tagged component assurance surfaces
+        run: python tools/stack_evaluate.py
+
+      - name: Generate correlated CTS evidence
+        working-directory: .stack-work/cts
+        env:
+          TRQP_RUN_ID: stack-${{ github.run_id }}
+          TRQP_TARGET_ID: trqp-reference-adopter
+        run: make assurance-check
+
+      - name: Generate deterministic CTS replay evidence
+        working-directory: .stack-work/cts
+        run: |
+          cp examples/sut.local.yaml.example examples/sut.local.yaml
+          python - <<'PY'
+          from pathlib import Path
+          from nacl.signing import SigningKey
+          from nacl.encoding import Base64Encoder
+          p = Path('examples/sut.local.yaml')
+          key = SigningKey.generate().encode(Base64Encoder).decode()
+          p.write_text(p.read_text(encoding='utf-8').replace('REPLACE_WITH_BASE64_ED25519_PRIVATE_KEY', key), encoding='utf-8')
+          PY
+          python cts/run.py --profile profiles/baseline.yaml --sut examples/sut.local.yaml --fixture-set fixtures/baseline.fixture-set.json --generated-at '2026-01-15T00:00:00Z' --run-id 'stack-fixture-baseline' --out reports/stack_fixture
+          set +e
+          python cts/run.py --profile profiles/baseline.yaml --sut examples/sut.local.yaml --replay reports/stack_fixture --generated-at '2026-01-15T00:00:00Z' --out reports/stack_fixture_replay
+          replay_exit=$?
+          set -e
+          test -f reports/stack_fixture_replay/replay-report.json || exit "${replay_exit:-1}"
+          python scripts/build_replay_determinism_report.py --source reports/stack_fixture --replay-report reports/stack_fixture_replay/replay-report.json --policy policies/replay-determinism.v1.json --out reports/stack_fixture_replay/determinism-report.json
+          python scripts/verify_replay_determinism.py reports/stack_fixture_replay/determinism-report.json
+
+      - name: Generate correlated TSPP evidence
+        working-directory: .stack-work/tspp
+        env:
+          TRQP_RUN_ID: stack-${{ github.run_id }}
+          TRQP_TARGET_ID: trqp-reference-adopter
+        run: make assurance-check
+
+      - name: Compose combined assurance twice
+        run: |
+          python tools/run_combined_assurance.py --cts-report .stack-work/cts/artifacts/validation/cts-report.json --cts-determinism-report .stack-work/cts/reports/stack_fixture_replay/determinism-report.json --tspp-report .stack-work/tspp/artifacts/validation/tspp-report.json --release-set ots-2026-08 --out artifacts/stack-candidate/run-a
+          python tools/run_combined_assurance.py --cts-report .stack-work/cts/artifacts/validation/cts-report.json --cts-determinism-report .stack-work/cts/reports/stack_fixture_replay/determinism-report.json --tspp-report .stack-work/tspp/artifacts/validation/tspp-report.json --release-set ots-2026-08 --out artifacts/stack-candidate/run-b
+
+      - name: Prove whole-stack semantic replay equivalence
+        run: |
+          python tools/stack_compare.py artifacts/stack-candidate/run-a/combined-assurance-manifest.json artifacts/stack-candidate/run-b/combined-assurance-manifest.json
+          python tools/stack_compare.py artifacts/stack-candidate/run-a/assurance-decision.json artifacts/stack-candidate/run-b/assurance-decision.json
+
+      - name: Verify fail-closed cross-stack cases
+        run: python -m pytest -q tests/test_cross_stack_negative_cases.py tests/test_cts_determinism.py tests/test_stack_release_readiness.py
+
+      - name: Publish candidate eligibility evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: trqp-stack-release-candidate-${{ github.run_id }}
+          path: |
+            artifacts/stack-candidate/
+            .stack-work/bootstrap-manifest.json
+            .stack-work/cts/artifacts/
+            .stack-work/cts/reports/stack_fixture_replay/determinism-report.json
+            .stack-work/tspp/artifacts/
+          if-no-files-found: error

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,23 +8,37 @@ nav_exclude: true
 
 ## Repository mandate
 
-`trqp-assurance-hub` is a Tier 1 flagship repository in the TRQP assurance stack. Its mandate is **assurance orchestration and publication**. The repository is maintained as executable governance: material claims should map to artifacts, validation, evidence, and a reviewable change record.
+`trqp-assurance-hub` is a Tier 1 flagship repository in the TRQP assurance stack. Its mandate is **assurance orchestration, publication, and coordinated stack-release declaration**. The repository is maintained as executable governance: material claims should map to artifacts, validation, evidence, and a reviewable change record.
 
 ## Authority
 
 This repository is authoritative for:
 
-- assurance evidence ingestion and composition
-- assurance profile evaluation
-- portable assurance publication
+- assurance evidence ingestion and composition;
+- assurance profile evaluation;
+- portable assurance publication;
+- coordinated TRQP Stack compatibility tuple declaration;
+- stack integration verification and release-eligibility evidence; and
+- the canonical adopter workflow for coordinated releases.
 
 This repository is not authoritative for:
 
-- the TRQP protocol specification
-- raw conformance test execution
-- TSPP control definition
+- the TRQP protocol specification;
+- raw conformance test execution or CTS replay-comparison semantics;
+- TSPP control definition or posture semantics;
+- TSMM semantic authority;
+- TIS schema authority; or
+- external certification/accreditation.
 
-Normative authority originating in an upstream specification remains with that specification and its governing body. Local profiles, mappings, examples, and implementation choices must not be represented as amendments to upstream standards.
+Normative authority originating in an upstream specification remains with that specification and its governing body. Local profiles, mappings, examples, release tuples, and implementation choices must not be represented as amendments to upstream standards.
+
+## Coordinated stack releases
+
+A coordinated TRQP Stack release is an interoperability and assurance declaration over an exact immutable component tuple. It does not replace component semantic versioning and does not transfer authority between repositories.
+
+A candidate may be promoted to a coordinated release only when the release-readiness gate demonstrates immutable tuple resolution, clean-room bootstrap, component execution, deterministic CTS replay, valid combined assurance, run/target correlation, provenance and integrity, fail-closed negative cases, and an executable adopter walkthrough.
+
+Changing a candidate to `validated`, creating a coordinated release tag, or publishing release notes is a deliberate maintainer action and is not performed automatically by readiness CI.
 
 ## Decision rights
 
@@ -36,7 +50,7 @@ Contributors may propose changes through pull requests. Review authority is dele
 
 ## Enforcement and revocation
 
-Non-conforming artifacts may be rejected, reverted, deprecated, or superseded. Compromised evidence, signing material, profiles, or implementation outputs must be withdrawn or marked invalid through the relevant lifecycle mechanism. Security reports follow [`SECURITY.md`](SECURITY.md).
+Non-conforming artifacts may be rejected, reverted, deprecated, revoked, or superseded. A coordinated stack tuple must be revoked or superseded when a component release, authority version, evidence chain, or security condition invalidates the release claim. Compromised evidence, signing material, profiles, or implementation outputs must be withdrawn or marked invalid through the relevant lifecycle mechanism. Security reports follow [`SECURITY.md`](SECURITY.md).
 
 ## Evidence and auditability
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate flagship-check assurance-check evidence
+.PHONY: validate flagship-check assurance-check evidence stack-release-check stack-bootstrap stack-evaluate
 
 validate:
 	python scripts/validate_repository.py
@@ -11,6 +11,16 @@ assurance-check: validate
 	python -m pytest -q tests/test_cross_stack_negative_cases.py
 
 evidence: assurance-check
+
+stack-release-check: validate
+	python tools/stack_validate.py --check-remote
+	python -m pytest -q tests/test_stack_release_readiness.py tests/test_cross_stack_negative_cases.py tests/test_cts_determinism.py
+
+stack-bootstrap:
+	python tools/stack_bootstrap.py --clean
+
+stack-evaluate:
+	python tools/stack_evaluate.py
 
 flagship-check:
 	python scripts/validate_repository.py

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -7,3 +7,11 @@ nav_exclude: true
 # Adoption Kit
 
 The adoption kit helps institutional users convert TRQP assurance artifacts into onboarding, procurement, and audit decisions.
+
+## Start with the coordinated stack
+
+For an end-to-end adopter path across TRQP-TSPP, the TRQP Conformance Suite and the TRQP Assurance Hub, use the [TRQP Stack quickstart](stack-quickstart.md).
+
+The quickstart pins an unreleased candidate compatibility tuple, verifies immutable tags and commits, bootstraps a clean workspace, executes the declared component assurance surfaces, and explains the evidence required before a coordinated stack release may be cut.
+
+Use the component repositories directly when you need to customize TSPP posture controls, CTS conformance/replay behavior, or Hub assurance composition. The coordinated stack does not transfer those repository-local authorities.

--- a/docs/adoption/stack-quickstart.md
+++ b/docs/adoption/stack-quickstart.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: "TRQP Stack quickstart"
+nav_exclude: true
+---
+
+# TRQP Stack quickstart
+
+Use this page when you want the validated TRQP components to behave as one adopter workflow rather than selecting repository versions independently.
+
+## 1. Inspect the candidate tuple
+
+The unreleased tuple is declared in `stack/releases/candidate/manifest.json`. It identifies the exact TSPP, Conformance Suite and Assurance Hub tags and commits, plus TSMM/TIS authority versions. A candidate is not a release.
+
+```bash
+python tools/stack_validate.py --check-remote
+```
+
+This fails if the manifest is incomplete, a component ref is mutable, or a declared tag does not resolve to the pinned commit.
+
+## 2. Bootstrap a clean workspace
+
+```bash
+python tools/stack_bootstrap.py --clean
+```
+
+The command clones only the tagged component versions in the manifest and verifies their commits. No adopter-side compatibility choice is required.
+
+## 3. Execute the declared components
+
+```bash
+python tools/stack_evaluate.py
+```
+
+This invokes each component's `assurance-check` surface and writes a candidate run record to `artifacts/stack-candidate/run-manifest.json`.
+
+## 4. Run the release-readiness gate
+
+```bash
+make stack-release-check
+```
+
+The local gate validates the Hub, the candidate tuple, remote tag provenance, and fail-closed release-readiness tests. GitHub Actions additionally runs the existing cross-repository combined-assurance flow against the same immutable TSPP/CTS releases.
+
+## Evidence expected before release
+
+A coordinated release is eligible only when CI demonstrates: immutable tuple resolution, clean bootstrap, TSPP evidence validity, CTS conformance and deterministic replay, shared run/target correlation, combined assurance, provenance/integrity, negative-case rejection, and an executable walkthrough.
+
+## Authority boundary
+
+The Assurance Hub owns coordinated release declaration and compatibility evidence. TSPP remains authoritative for its controls and posture semantics. CTS remains authoritative for protocol conformance and replay-comparison semantics. TSMM/TIS retain their declared semantic/schema authority. A stack release therefore records tested interoperability; it does not transfer normative authority.
+
+## Release prohibition
+
+Do not change the candidate status to `validated`, create a Stack tag, or publish a coordinated release until the release-readiness workflow is green and the maintainer deliberately performs the release step.

--- a/stack/examples/canonical-adopter/README.md
+++ b/stack/examples/canonical-adopter/README.md
@@ -1,0 +1,35 @@
+# Canonical TRQP stack adopter case
+
+This fixture is the adopter-facing reference target for coordinated TRQP Stack release eligibility. It exists to prove that a new adopter can start from the Assurance Hub, resolve one declared component tuple, run the three repositories, and inspect evidence without independently choosing compatible versions.
+
+## Decisive test
+
+A stack candidate is eligible only when the following are demonstrated against the declared immutable component tuple:
+
+1. the release tuple resolves to the declared tags and commits;
+2. a clean workspace can bootstrap all three components;
+3. TSPP and CTS execute their assurance surfaces;
+4. CTS replay evidence is deterministic under its declared comparison policy;
+5. the Hub consumes correlated evidence and fails closed on invalid inputs;
+6. provenance and integrity are preserved; and
+7. the documented walkthrough remains executable.
+
+The target descriptor in `target.json` is deliberately small: it defines the shared identity and expected cross-stack properties while the authoritative producer fixtures and evidence semantics remain in TSPP and CTS.
+
+## Run
+
+From the Assurance Hub repository root:
+
+```bash
+make stack-release-check
+```
+
+For an explicit clean-room run:
+
+```bash
+python tools/stack_validate.py --check-remote
+python tools/stack_bootstrap.py --clean
+python tools/stack_evaluate.py
+```
+
+These commands produce candidate validation evidence only. They do not publish or imply a coordinated TRQP Stack release.

--- a/stack/examples/canonical-adopter/target.json
+++ b/stack/examples/canonical-adopter/target.json
@@ -1,0 +1,13 @@
+{
+  "target_id": "trqp-reference-adopter",
+  "description": "Canonical coordinated-stack target used to prove adopter bootstrap, execution, evidence correlation, replay and fail-closed behavior.",
+  "assurance_profile": "baseline",
+  "expected_properties": {
+    "shared_run_id": true,
+    "shared_target_id": true,
+    "cts_replay_deterministic": true,
+    "combined_assurance_required": true,
+    "provenance_required": true,
+    "artifact_integrity_required": true
+  }
+}

--- a/stack/releases/candidate/manifest.json
+++ b/stack/releases/candidate/manifest.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0",
+  "stack": {
+    "id": "trqp-stack-candidate-2026.1",
+    "status": "candidate"
+  },
+  "components": {
+    "tspp": {
+      "repository": "sankarshanmukhopadhyay/TRQP-TSPP",
+      "ref": "v0.15.0",
+      "commit": "55d52bc115af2b878c16519e4c79d62c3ed8caf7"
+    },
+    "cts": {
+      "repository": "sankarshanmukhopadhyay/trqp-conformance-suite",
+      "ref": "v1.8.0",
+      "commit": "024e88dd9739e7656e49f2129ea1df8a15b7482c"
+    },
+    "assurance_hub": {
+      "repository": "sankarshanmukhopadhyay/trqp-assurance-hub",
+      "ref": "v1.11.0",
+      "commit": "cda924bae643b23d624a8eb41d8c41fae93c481b"
+    }
+  },
+  "authorities": {
+    "tsmm": {"repository": "sankarshanmukhopadhyay/trust-systems-meta-model", "ref": "v0.24.0"},
+    "tis": {"repository": "sankarshanmukhopadhyay/trust-infrastructure-schemas", "ref": "v0.14.1"}
+  },
+  "release_gates": [
+    "release-tuple-resolves",
+    "tagged-commits-match",
+    "clean-bootstrap",
+    "canonical-evaluation",
+    "tspp-evidence-valid",
+    "cts-evidence-valid",
+    "cts-replay-deterministic",
+    "combined-assurance-valid",
+    "run-target-correlation",
+    "provenance-complete",
+    "artifact-integrity-valid",
+    "negative-cases-fail-closed",
+    "full-stack-replay-equivalent",
+    "walkthrough-executable"
+  ]
+}

--- a/stack/schema/release-manifest.schema.json
+++ b/stack/schema/release-manifest.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sankarshanmukhopadhyay.github.io/trqp-assurance-hub/schemas/stack-release-manifest.schema.json",
+  "title": "TRQP coordinated stack release manifest",
+  "type": "object",
+  "required": ["schema_version", "stack", "components", "authorities", "release_gates"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "stack": {
+      "type": "object",
+      "required": ["id", "status"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "status": {"enum": ["candidate", "validated", "revoked", "superseded"]}
+      },
+      "additionalProperties": false
+    },
+    "components": {
+      "type": "object",
+      "required": ["tspp", "cts", "assurance_hub"],
+      "additionalProperties": {
+        "type": "object",
+        "required": ["repository", "ref", "commit"],
+        "properties": {
+          "repository": {"type": "string", "minLength": 1},
+          "ref": {"type": "string", "pattern": "^v"},
+          "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "authorities": {"type": "object", "required": ["tsmm", "tis"]},
+    "release_gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_stack_release_readiness.py
+++ b/tests/test_stack_release_readiness.py
@@ -1,0 +1,41 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("stack_validate", ROOT / "tools" / "stack_validate.py")
+stack_validate = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(stack_validate)
+
+
+def manifest():
+    return json.loads((ROOT / "stack" / "releases" / "candidate" / "manifest.json").read_text())
+
+
+def test_candidate_manifest_is_structurally_eligible():
+    assert stack_validate.validate_structure(manifest()) == []
+
+
+def test_missing_component_fails_closed():
+    candidate = manifest()
+    candidate["components"].pop("cts")
+    assert stack_validate.validate_structure(candidate)
+
+
+def test_mutable_component_ref_fails_closed():
+    candidate = manifest()
+    candidate["components"]["cts"]["ref"] = "main"
+    assert any("immutable version tag" in error for error in stack_validate.validate_structure(candidate))
+
+
+def test_invalid_component_provenance_fails_closed():
+    candidate = manifest()
+    candidate["components"]["tspp"]["commit"] = "deadbeef"
+    assert any("40-character commit SHA" in error for error in stack_validate.validate_structure(candidate))
+
+
+def test_all_decisive_release_gates_are_declared():
+    candidate = manifest()
+    assert stack_validate.REQUIRED_GATES <= set(candidate["release_gates"])

--- a/tools/stack_bootstrap.py
+++ b/tools/stack_bootstrap.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Clone the exact tagged component tuple declared by a TRQP stack manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="stack/releases/candidate/manifest.json")
+    parser.add_argument("--workspace", default=".stack-work")
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    workspace = Path(args.workspace)
+    if args.clean and workspace.exists():
+        shutil.rmtree(workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    for name, component in manifest["components"].items():
+        target = workspace / name
+        if target.exists():
+            shutil.rmtree(target)
+        url = f"https://github.com/{component['repository']}.git"
+        run(["git", "clone", "--quiet", "--depth", "1", "--branch", component["ref"], url, str(target)])
+        actual = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=target, text=True).strip()
+        if actual != component["commit"]:
+            raise SystemExit(f"{name}: expected {component['commit']} but checked out {actual}")
+        print(f"[PASS] {name}: {component['ref']} @ {actual}")
+
+    (workspace / "bootstrap-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"[PASS] clean-room stack workspace ready at {workspace}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stack_compare.py
+++ b/tools/stack_compare.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Compare two JSON assurance artifacts for semantic equivalence."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+DEFAULT_VOLATILE = {"generated_at", "evaluated_at", "created_at", "timestamp", "run_id"}
+
+
+def canonical(value, volatile=DEFAULT_VOLATILE):
+    if isinstance(value, dict):
+        return {k: canonical(v, volatile) for k, v in sorted(value.items()) if k not in volatile}
+    if isinstance(value, list):
+        return [canonical(v, volatile) for v in value]
+    return value
+
+
+def digest(path: Path) -> str:
+    data = canonical(json.loads(path.read_text(encoding="utf-8")))
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("left")
+    parser.add_argument("right")
+    args = parser.parse_args()
+    left, right = digest(Path(args.left)), digest(Path(args.right))
+    if left != right:
+        print(f"[FAIL] semantic digests differ: {left} != {right}")
+        return 1
+    print(f"[PASS] semantic replay equivalent: {left}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stack_evaluate.py
+++ b/tools/stack_evaluate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Execute the declared TRQP component validation surfaces from a clean-room workspace."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def run_make(path: Path, target: str) -> dict:
+    proc = subprocess.run(["make", target], cwd=path, text=True, capture_output=True)
+    return {
+        "target": target,
+        "returncode": proc.returncode,
+        "stdout_sha256": hashlib.sha256(proc.stdout.encode()).hexdigest(),
+        "stderr_sha256": hashlib.sha256(proc.stderr.encode()).hexdigest(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", default=".stack-work")
+    parser.add_argument("--output", default="artifacts/stack-candidate/run-manifest.json")
+    args = parser.parse_args()
+    workspace = Path(args.workspace)
+    manifest = json.loads((workspace / "bootstrap-manifest.json").read_text(encoding="utf-8"))
+
+    results = {}
+    for name in ("tspp", "cts", "assurance_hub"):
+        results[name] = run_make(workspace / name, "assurance-check")
+
+    passed = all(result["returncode"] == 0 for result in results.values())
+    record = {
+        "stack_id": manifest["stack"]["id"],
+        "evaluated_at": datetime.now(timezone.utc).isoformat(),
+        "components": manifest["components"],
+        "results": results,
+        "eligible_component_execution": passed,
+        "note": "This run record is candidate evidence and is not a coordinated release declaration."
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    for name, result in results.items():
+        print(f"[{'PASS' if result['returncode'] == 0 else 'FAIL'}] {name} assurance-check")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stack_validate.py
+++ b/tools/stack_validate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate a coordinated TRQP stack candidate manifest and release eligibility evidence."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+REQUIRED_COMPONENTS = {"tspp", "cts", "assurance_hub"}
+REQUIRED_AUTHORITIES = {"tsmm", "tis"}
+REQUIRED_GATES = {
+    "release-tuple-resolves", "tagged-commits-match", "clean-bootstrap",
+    "canonical-evaluation", "tspp-evidence-valid", "cts-evidence-valid",
+    "cts-replay-deterministic", "combined-assurance-valid", "run-target-correlation",
+    "provenance-complete", "artifact-integrity-valid", "negative-cases-fail-closed",
+    "full-stack-replay-equivalent", "walkthrough-executable"
+}
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_structure(doc: dict) -> list[str]:
+    errors: list[str] = []
+    if doc.get("schema_version") != "1.0": errors.append("schema_version must be 1.0")
+    stack = doc.get("stack", {})
+    if stack.get("status") not in {"candidate", "validated", "revoked", "superseded"}: errors.append("invalid stack status")
+    components = doc.get("components", {})
+    if set(components) != REQUIRED_COMPONENTS: errors.append("components must be exactly tspp, cts, assurance_hub")
+    for name, component in components.items():
+        if not component.get("repository"): errors.append(f"{name}: repository missing")
+        if not str(component.get("ref", "")).startswith("v"): errors.append(f"{name}: immutable version tag required")
+        if not SHA40.match(str(component.get("commit", ""))): errors.append(f"{name}: 40-character commit SHA required")
+    if not REQUIRED_AUTHORITIES.issubset(doc.get("authorities", {})): errors.append("tsmm and tis authorities are required")
+    gates = set(doc.get("release_gates", []))
+    missing = REQUIRED_GATES - gates
+    if missing: errors.append("missing release gates: " + ", ".join(sorted(missing)))
+    return errors
+
+
+def verify_remote_refs(doc: dict) -> list[str]:
+    errors: list[str] = []
+    for name, component in doc["components"].items():
+        url = f"https://github.com/{component['repository']}.git"
+        ref = f"refs/tags/{component['ref']}^{{}}"
+        fallback = f"refs/tags/{component['ref']}"
+        proc = subprocess.run(["git", "ls-remote", url, ref, fallback], capture_output=True, text=True)
+        if proc.returncode != 0 or not proc.stdout.strip():
+            errors.append(f"{name}: unable to resolve {component['ref']}")
+            continue
+        resolved = [line.split()[0] for line in proc.stdout.splitlines() if line.strip()]
+        if component["commit"] not in resolved:
+            errors.append(f"{name}: tag does not resolve to declared commit")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", nargs="?", default="stack/releases/candidate/manifest.json")
+    parser.add_argument("--check-remote", action="store_true")
+    args = parser.parse_args()
+    doc = load(Path(args.manifest))
+    errors = validate_structure(doc)
+    if args.check_remote and not errors:
+        errors.extend(verify_remote_refs(doc))
+    if errors:
+        for error in errors: print(f"[FAIL] {error}")
+        return 1
+    print("[PASS] coordinated stack manifest is structurally valid")
+    if args.check_remote: print("[PASS] tagged component commits match manifest")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Promotes the existing synchronized TRQP Operational Trust Stack into an explicit, machine-verifiable coordinated-release candidate without publishing a release.

## Implements steps 1–9

1. formalizes Assurance Hub authority for coordinated stack compatibility/release declarations;
2. adds a machine-readable candidate release manifest and schema;
3. consumes the newly formalized TSPP producer boundary;
4. consumes the newly formalized CTS producer boundary;
5. adds clean-room immutable-tag bootstrap and commit verification;
6. adds a canonical adopter target and front-door workflow;
7. adds fail-closed release tests and whole-stack semantic replay comparison;
8. adds an executable adopter quickstart;
9. adds a dedicated `stack-release-eligibility` CI gate that reproduces tagged component evidence, deterministic CTS replay, combined assurance, negative cases and candidate evidence publication.

## Explicit non-goal

This PR does **not** perform step 10. It does not create a TRQP Stack tag, change the candidate to `validated`, or publish a coordinated release.

## Authority and assurance

TSPP retains authority over controls/posture semantics. CTS retains authority over protocol conformance and replay-comparison semantics. The Hub owns compatibility tuple declaration, integration verification, combined assurance and release-eligibility evidence. TSMM/TIS authority remains external and explicitly pinned.

## Validation

The PR adds `make stack-release-check` plus the dedicated release-eligibility workflow. A release should only be cut after this workflow is green on the merged baseline.