### PR TITLE
release(stack): prepare TRQP Stack 2026.1 Coconut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,89 @@
 ---
 owner: maintainers
-last_reviewed: 2026-08-22
+last_reviewed: 2026-08-25
 tier: 0
 ---
 
 # TRQP Assurance Hub
 
-The TRQP Assurance Hub is the **evidence aggregation and assurance publication layer** in the TRQP Operational Trust Stack. It combines protocol-conformance evidence from the TRQP Conformance Suite with security/privacy posture evidence from TRQP-TSPP, evaluates the declared assurance profile, and publishes a machine-readable Combined Assurance Manifest and assurance decision for downstream review.
+The TRQP Assurance Hub is the **evidence aggregation, compatibility coordination, and assurance publication layer** in the TRQP Operational Trust Stack. It combines protocol-conformance evidence from the TRQP Conformance Suite with security/privacy posture evidence from TRQP-TSPP, evaluates the declared assurance profile, and publishes machine-readable combined assurance for downstream review.
 
-> **Current release:** v1.11.0  
+It is also the **adopter front door and coordinated Stack release authority**. A coordinated Stack release does not create a fourth implementation product; it declares which independently versioned component releases have been exercised together and preserves the evidence behind that claim.
+
+> **Current Hub component release:** v1.11.0  
+> **Current coordinated stack:** TRQP Stack 2026.1 — Coconut  
 > **Lifecycle:** Active  
 > **Maturity:** Candidate  
-> **Operational status:** Active validation  
-> **Specification status:** Candidate specification
+> **Operational status:** Active validation
 
 | Attribute | Value |
 |---|---|
-| Portfolio tier | Flagship |
-| Primary role | Assurance evidence ingestion, composition and publication |
+| Primary role | Assurance aggregation, compatibility coordination, release evidence publication |
 | Portfolio contract role | `assurance-aggregator` |
 | Primary output | Combined Assurance Manifest and assurance decision |
-| Validation | `make validate` |
-| Assurance evidence | `make assurance-check` |
-| Evidence output | `artifacts/combined-assurance/combined-assurance-manifest.json`, `artifacts/combined-assurance/assurance-decision.json`, `artifacts/combined-assurance/traceability-report.json` |
-| Governance authority | [`GOVERNANCE.md`](GOVERNANCE.md) and [`PROJECT-STATUS.yaml`](PROJECT-STATUS.yaml) |
-| Portfolio integration | [`portfolio/integration-contract.json`](portfolio/integration-contract.json) |
+| Repository validation | `make validate` |
+| Combined assurance | `make assurance-check` |
+| Stack release gate | `make stack-release-check` |
+| Current Stack record | [`stack/releases/2026.1/`](stack/releases/2026.1/) |
+| Canonical adopter workflow | [`docs/adoption/stack-quickstart.md`](docs/adoption/stack-quickstart.md) |
 | Documentation site | https://sankarshanmukhopadhyay.github.io/trqp-assurance-hub/ |
 
-## What v1.11.0 establishes
+## Start here: TRQP Stack 2026.1 — Coconut
 
-v1.11.0 promotes CTS evidence reproducibility into the Hub's executable assurance boundary.
+If your goal is to adopt, evaluate, procure, or assess the complete TRQP assurance workflow, **start with the coordinated Stack release rather than choosing repository versions independently**.
 
-- Consumes **TRQP Conformance Suite v1.8.0** conformance evidence and replay-determinism evidence.
-- Pins **TRQP-TSPP v0.15.0** for the coordinated August 2026 release tuple.
-- Preserves the CTS replay comparison policy ID, version and SHA-256 in the combined assurance evidence chain.
-- Fails closed when CTS replay determinism is missing, malformed, false, or contains prohibited semantic differences.
-- Distinguishes a conformance failure from an evidence-reproducibility failure; both are material assurance signals but they are not the same condition.
-- Pins **Trust Systems Meta-Model (TSMM) v0.24.0** as semantic authority and **Trust Infrastructure Schemas (TIS) v0.14.1** as schema/portfolio authority.
+TRQP Stack 2026.1 — Coconut validates this tuple:
+
+| Layer | Release | Authority / output |
+|---|---:|---|
+| TRQP-TSPP | v0.15.0 | Security/privacy controls and posture evidence |
+| TRQP Conformance Suite | v1.8.0 | Protocol conformance and deterministic replay evidence |
+| TRQP Assurance Hub | v1.11.0 | Evidence aggregation and assurance publication |
+| TSMM | v0.24.0 | Semantic authority |
+| TIS | v0.14.1 | Schema and portfolio authority |
+
+The canonical machine-readable release record is [`stack/releases/2026.1/manifest.json`](stack/releases/2026.1/manifest.json). The human-readable release explanation is [`stack/releases/2026.1/README.md`](stack/releases/2026.1/README.md).
+
+### Why an adopter benefits
+
+A coordinated Stack release answers the compatibility question before deployment: **which exact versions are known to work together under the declared assurance model?**
+
+The release gate verifies immutable component resolution, clean-room bootstrap, component evidence generation, deterministic CTS replay, combined-assurance validation, cross-repository run/target correlation, provenance and artifact integrity, fail-closed negative cases, whole-stack semantic replay equivalence, and the executable adopter walkthrough.
+
+This means an adopter can select one validated tuple, reproduce it, inspect every underlying authority boundary, and obtain a portable evidence chain without reverse-engineering compatibility across three repositories.
 
 ## Authority and scope
 
-The Assurance Hub has repository-local authority over:
+The Hub is authoritative for:
 
 - assurance evidence ingestion and composition;
 - assurance profile evaluation;
+- combined assurance decision generation;
 - portable assurance publication;
-- combined assurance decision generation; and
-- interpretation of CTS replay-determinism evidence for Hub assurance decisions.
+- coordinated compatibility tuple declaration;
+- Stack integration verification; and
+- coordinated release eligibility evidence.
 
-The Hub **does not** own the TRQP protocol specification, raw conformance execution, the CTS replay comparison policy, TSPP control definitions, or external certification/accreditation. Those boundaries are declared in [`PROJECT-STATUS.yaml`](PROJECT-STATUS.yaml) and [`portfolio/integration-contract.json`](portfolio/integration-contract.json).
+The Hub **does not** own the upstream TRQP protocol specification, TSPP control/posture semantics, CTS raw conformance execution or replay-comparison semantics, TSMM semantics, TIS schema authority, or external certification/accreditation.
 
-## Where this fits
-
-| Layer | Repository role | Primary output |
-|---|---|---|
-| TRQP-TSPP v0.15.0 | Security/privacy posture computation | Posture Report and control evidence |
-| TRQP Conformance Suite v1.8.0 | Executable protocol conformance + reproducibility | Conformance evidence + replay determinism report |
-| TRQP Assurance Hub v1.11.0 | Evidence aggregation and assurance publication | Combined Assurance Manifest and assurance decision |
-
-Shared authorities:
-
-| Authority | Version | Purpose |
-|---|---:|---|
-| Trust Systems Meta-Model | 0.24.0 | TRQP semantic binding and semantic concepts |
-| Trust Infrastructure Schemas | 0.14.1 | Portfolio relationships, repository authority and validation-result contracts |
-
-The Hub integration becomes invalid when required source evidence is missing, source assurance evidence is invalid, CTS replay determinism is invalid or policy-incompatible, or the declared semantic/schema authority versions are incompatible.
+A Stack release therefore proves tested interoperability without collapsing repository-local authority.
 
 ## Runtime assurance flow
 
 ```text
-TRQP-TSPP Posture Report
-            +
-TRQP Conformance Suite evidence
-            +
-CTS replay determinism report + comparison-policy identity
-            ↓
+TRQP-TSPP posture/control evidence
+                +
+TRQP Conformance Suite conformance evidence
+                +
+CTS deterministic replay evidence
+                ↓
+      TRQP Assurance Hub
+                ↓
 Combined Assurance Manifest
-            ↓
-Assurance decision + traceability report
-            ↓
-Relying-party, assessor, procurement or ecosystem review
++ assurance decision
++ traceability report
+                ↓
+Relying-party / assessor / procurement / ecosystem review
 ```
 
 The machine-readable authority chain is:
@@ -90,96 +93,56 @@ TSMM semantic authority
         ↓
 TIS schema / portfolio authority
         ↓
-TSPP posture evidence + CTS conformance/reproducibility evidence
+TSPP posture evidence + CTS conformance/replay evidence
         ↓
-Assurance Hub aggregation
+Assurance Hub aggregation + coordinated-release evidence
 ```
-
-A passing test run alone is not an assurance conclusion. The Hub preserves who had authority, what scope was evaluated, which evidence was consumed, whether CTS evidence was reproducible under its declared comparison policy, what lifecycle/revocation state applies, and what condition would invalidate the combined result.
 
 ## Evidence artifacts
 
-| Artifact | Purpose | Schema or source |
-|---|---|---|
-| Combined Assurance Manifest | Binds CTS, CTS replay determinism and TSPP evidence to one assurance chain | `artifacts/combined-assurance/combined-assurance-manifest.json` |
-| Assurance decision | Machine-readable combined assurance outcome | `schemas/assurance-decision.schema.json` |
-| Traceability report | Cross-repository evidence/control/reproducibility traceability | `artifacts/combined-assurance/traceability-report.json` |
-| CTS replay determinism report | Evidence-equivalence result consumed from CTS v1.8.0 | CTS `schemas/evidence/replay-determinism-report.schema.json` |
-| CTS replay comparison policy | Declared semantic/volatile comparison boundary | CTS `policies/replay-determinism.v1.json` |
-| Public Assurance Summary | Relying-party-facing assurance publication | `schemas/public-assurance-summary.schema.json` |
-| Machine-readable assurance profile | Declares AL1–AL4 expectations | `schemas/machine-readable-assurance-profile.schema.json` |
-| Control satisfaction evidence | Maps controls to evidence artifacts | `schemas/control-satisfaction.schema.json` |
-| Certification attestation | Binds assessor, scope, validity and evidence when used | `schemas/certification-attestation.schema.json` |
+Primary Hub outputs include:
 
-## Start here
+- `artifacts/combined-assurance/combined-assurance-manifest.json`;
+- `artifacts/combined-assurance/assurance-decision.json`; and
+- `artifacts/combined-assurance/traceability-report.json`.
 
+A passing test run alone is not an assurance conclusion. The evidence chain preserves authority, evaluated scope, producer versions, run and target identity, replay-policy provenance, lifecycle/invalidation conditions, and the evidence consumed by the final decision.
+
+## Decisive Stack release gate
+
+Run:
+
+```bash
+make stack-release-check
+```
+
+The dedicated `stack-release-eligibility` GitHub Actions workflow extends this with tagged component execution, clean bootstrap, deterministic replay, full combined-assurance composition, semantic replay comparison, negative cases, and candidate evidence publication.
+
+For TRQP Stack 2026.1 — Coconut, the decisive workflow completed successfully on the merged Hub `main` baseline at commit `045ba10ec436ea5d1e9e443894bbbf7bea27472b`. The release record preserves the workflow run and evidence artifact digest.
+
+## Adoption and implementation guides
+
+- [`docs/adoption/stack-quickstart.md`](docs/adoption/stack-quickstart.md) — canonical end-to-end Stack workflow.
 - [`docs/guides/combined-assurance.md`](docs/guides/combined-assurance.md) — compose CTS and TSPP evidence.
 - [`docs/guides/evidence-artifacts.md`](docs/guides/evidence-artifacts.md) — evidence artifact model.
 - [`docs/guides/public-assurance-publication.md`](docs/guides/public-assurance-publication.md) — publish relying-party-facing assurance.
-- [`docs/adoption/README.md`](docs/adoption/README.md) — adoption checklists.
-- [`docs/reference/compatibility-matrix.md`](docs/reference/compatibility-matrix.md) — supported release relationships.
-- [`docs/reference/tsmm-tis-runtime-assurance-contract.md`](docs/reference/tsmm-tis-runtime-assurance-contract.md) — semantic/artifact contract background.
-- [`docs/portfolio-integration.md`](docs/portfolio-integration.md) — synchronized TRQP portfolio integration.
-- [`docs/governance/release-policy.md`](docs/governance/release-policy.md) — release governance.
-- [`docs/governance/change-intake.md`](docs/governance/change-intake.md) — change intake criteria.
+- [`docs/reference/compatibility-matrix.md`](docs/reference/compatibility-matrix.md) — supported component relationships.
+- [`docs/portfolio-integration.md`](docs/portfolio-integration.md) — synchronized portfolio integration.
+- [`docs/governance/release-policy.md`](docs/governance/release-policy.md) — component and coordinated Stack release governance.
 
-## Quick validation
+## Release cadence
 
-Run the repository validation gate:
+Component repositories retain independent semantic versioning. Coordinated Stack releases are expected approximately monthly when meaningful capability has accumulated, and earlier when a capability, compatibility, security, evidence, or authority change makes a new validated tuple materially useful or necessary.
 
-```bash
-make validate
-```
+Each coordinated Stack release receives a randomly selected codename from the Wikipedia list of Indian state trees. The codename is human-facing identity only; the stable machine identity remains `trqp-stack-YYYY.N`.
 
-Run the cross-stack negative-case assurance checks:
+## Invalidation and supersession
 
-```bash
-make assurance-check
-```
+Combined assurance and coordinated-release claims are conditional. Missing evidence, invalid producer evidence, incompatible semantic/schema authorities, failed CTS replay determinism, replay-policy incompatibility, or other declared invalidation conditions can make a tuple unsuitable for continued use.
 
-The coordinated smoke workflow additionally generates CTS v1.8.0 fixture-pinned replay evidence, verifies its determinism report, then requires that report during Hub composition.
+Historical Stack manifests are retained as immutable evidence. Changed compatibility conditions require a new release or explicit supersession rather than silent rewriting.
 
-## Operational stack integration
-
-CTS and TSPP evidence must share the same `run_id` and `target_id` before aggregation. For the v1.11.0 release tuple, CTS replay determinism evidence is also mandatory and is preserved in the Combined Assurance Manifest with policy identity and semantic hashes.
-
-The synchronized release tuple is:
-
-```text
-TRQP-TSPP              v0.15.0
-TRQP Conformance Suite v1.8.0
-TRQP Assurance Hub     v1.11.0
-TSMM                    v0.24.0
-TIS                     v0.14.1
-```
-
-The CI smoke test checks out the tagged CTS/TSPP releases rather than mutable `main` branches.
-
-## Repository map
-
-| Path | Purpose |
-|---|---|
-| `schemas/` | Combined assurance, profile, control-satisfaction and publication schemas |
-| `profiles/` | Machine-readable assurance profiles |
-| `tools/` | Manifest generation, CTS determinism validation and operational-stack tooling |
-| `artifacts/combined-assurance/` | Current combined assurance evidence |
-| `examples/` | Example source and output artifacts |
-| `portfolio/` | Cross-repository integration contract |
-| `docs/guides/` | Operational assurance guidance |
-| `docs/reference/` | Compatibility and semantic/artifact contract references |
-| `docs/adoption/` | Adoption and implementation checklists |
-
-## Invalidation, supersession and auditability
-
-Combined assurance is explicitly conditional. It can be invalidated by incompatible semantic/schema authority versions, missing required source evidence, invalid source assurance evidence, failed CTS replay determinism, or a CTS replay comparison policy that the Hub release tuple does not recognise as compatible. Releases and status claims are superseded through versioned repository artifacts rather than silently rewriting historical evidence.
-
-Example or self-generated evidence does not constitute independent assurance, certification or accreditation.
-
-## Documentation site
-
-GitHub Pages uses Just the Docs and is deployed from `main` through GitHub Actions. Repository administrators should configure **Settings → Pages → Source: GitHub Actions**.
-
-Documentation governance: [`docs/governance/README.md`](docs/governance/README.md).
+Example or self-generated evidence does not constitute independent assurance, certification, or accreditation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ It is also the **adopter front door and coordinated Stack release authority**. A
 
 | Attribute | Value |
 |---|---|
+| Portfolio tier | Flagship |
 | Primary role | Assurance aggregation, compatibility coordination, release evidence publication |
 | Portfolio contract role | `assurance-aggregator` |
 | Primary output | Combined Assurance Manifest and assurance decision |
-| Repository validation | `make validate` |
-| Combined assurance | `make assurance-check` |
+| Validation | `make validate` |
+| Assurance evidence | `make assurance-check` |
 | Stack release gate | `make stack-release-check` |
+| Evidence output | `artifacts/combined-assurance/combined-assurance-manifest.json`, `artifacts/combined-assurance/assurance-decision.json`, `artifacts/combined-assurance/traceability-report.json` |
+| Governance authority | [`GOVERNANCE.md`](GOVERNANCE.md) and [`PROJECT-STATUS.yaml`](PROJECT-STATUS.yaml) |
 | Current Stack record | [`stack/releases/2026.1/`](stack/releases/2026.1/) |
 | Canonical adopter workflow | [`docs/adoption/stack-quickstart.md`](docs/adoption/stack-quickstart.md) |
 | Documentation site | https://sankarshanmukhopadhyay.github.io/trqp-assurance-hub/ |

--- a/docs/adoption/stack-quickstart.md
+++ b/docs/adoption/stack-quickstart.md
@@ -8,48 +8,80 @@ nav_exclude: true
 
 Use this page when you want the validated TRQP components to behave as one adopter workflow rather than selecting repository versions independently.
 
-## 1. Inspect the candidate tuple
+## Current validated release
 
-The unreleased tuple is declared in `stack/releases/candidate/manifest.json`. It identifies the exact TSPP, Conformance Suite and Assurance Hub tags and commits, plus TSMM/TIS authority versions. A candidate is not a release.
+**TRQP Stack 2026.1 — Coconut** is the current coordinated release. Its immutable record is `stack/releases/2026.1/manifest.json` and its human-readable explanation is `stack/releases/2026.1/README.md`.
+
+The validated tuple is:
+
+| Layer | Release |
+|---|---:|
+| TRQP-TSPP | v0.15.0 |
+| TRQP Conformance Suite | v1.8.0 |
+| TRQP Assurance Hub | v1.11.0 |
+| TSMM | v0.24.0 |
+| TIS | v0.14.1 |
+
+## 1. Understand the release contract
+
+A coordinated Stack release means the declared component versions have been exercised together under the Stack eligibility gate. It removes adopter-side version selection while preserving the independent authority and version lifecycle of each repository.
+
+For future releases, the next proposed tuple is first recorded in `stack/releases/candidate/manifest.json`. A candidate is not a release.
+
+## 2. Validate the candidate or current tuple
+
+For release engineering against the current candidate:
 
 ```bash
 python tools/stack_validate.py --check-remote
 ```
 
-This fails if the manifest is incomplete, a component ref is mutable, or a declared tag does not resolve to the pinned commit.
+This fails if the candidate manifest is incomplete, a component ref is mutable, or a declared tag does not resolve to the pinned commit.
 
-## 2. Bootstrap a clean workspace
+For adoption of Stack 2026.1, inspect `stack/releases/2026.1/manifest.json` for the immutable component tags, commits, authority versions, decisive workflow run, and evidence artifact digest.
+
+## 3. Bootstrap a clean workspace
 
 ```bash
 python tools/stack_bootstrap.py --clean
 ```
 
-The command clones only the tagged component versions in the manifest and verifies their commits. No adopter-side compatibility choice is required.
+The bootstrap command clones only the tagged component versions declared by the candidate release engineering manifest and verifies their commits. No adopter-side compatibility choice is required.
 
-## 3. Execute the declared components
+The same clean-room property was a mandatory eligibility condition for Stack 2026.1.
+
+## 4. Execute the declared components
 
 ```bash
 python tools/stack_evaluate.py
 ```
 
-This invokes each component's `assurance-check` surface and writes a candidate run record to `artifacts/stack-candidate/run-manifest.json`.
+This invokes each component's `assurance-check` surface and writes a run record to `artifacts/stack-candidate/run-manifest.json` during release engineering.
 
-## 4. Run the release-readiness gate
+The coordinated Stack workflow then correlates TSPP and CTS evidence using the same run and target identity before the Hub produces combined assurance.
+
+## 5. Verify release eligibility
 
 ```bash
 make stack-release-check
 ```
 
-The local gate validates the Hub, the candidate tuple, remote tag provenance, and fail-closed release-readiness tests. GitHub Actions additionally runs the existing cross-repository combined-assurance flow against the same immutable TSPP/CTS releases.
+The local gate validates the Hub, candidate tuple, remote tag provenance, and fail-closed release-readiness tests. The `stack-release-eligibility` GitHub Actions workflow additionally performs clean bootstrap, tagged component execution, CTS deterministic replay, combined assurance composition, whole-stack semantic replay comparison, negative cases, and candidate evidence publication.
 
-## Evidence expected before release
+Stack 2026.1 passed that decisive workflow on the merged Hub baseline before its release record was promoted to `validated`.
 
-A coordinated release is eligible only when CI demonstrates: immutable tuple resolution, clean bootstrap, TSPP evidence validity, CTS conformance and deterministic replay, shared run/target correlation, combined assurance, provenance/integrity, negative-case rejection, and an executable walkthrough.
+## Evidence a coordinated release provides
+
+A coordinated release is publishable only when CI demonstrates immutable tuple resolution, clean bootstrap, TSPP evidence validity, CTS conformance and deterministic replay, shared run/target correlation, combined assurance, provenance/integrity, negative-case rejection, whole-stack semantic replay equivalence, and an executable walkthrough.
+
+The release record preserves the exact workflow run and evidence artifact digest so the claim can be audited later.
 
 ## Authority boundary
 
-The Assurance Hub owns coordinated release declaration and compatibility evidence. TSPP remains authoritative for its controls and posture semantics. CTS remains authoritative for protocol conformance and replay-comparison semantics. TSMM/TIS retain their declared semantic/schema authority. A stack release therefore records tested interoperability; it does not transfer normative authority.
+The Assurance Hub owns coordinated release declaration and compatibility evidence. TSPP remains authoritative for its controls and posture semantics. CTS remains authoritative for protocol conformance and replay-comparison semantics. TSMM/TIS retain their declared semantic/schema authority.
 
-## Release prohibition
+A Stack release therefore records **tested interoperability and assurance evidence**; it does not transfer normative authority.
 
-Do not change the candidate status to `validated`, create a Stack tag, or publish a coordinated release until the release-readiness workflow is green and the maintainer deliberately performs the release step.
+## Release cadence
+
+Coordinated Stack releases are expected approximately monthly when meaningful capability has accumulated, or earlier when a capability/compatibility change makes a new validated tuple materially useful or necessary. Component releases continue independently and do not automatically trigger a Stack release.

--- a/docs/governance/release-policy.md
+++ b/docs/governance/release-policy.md
@@ -1,38 +1,78 @@
 ---
 owner: maintainers
-last_reviewed: 2026-07-03
+last_reviewed: 2026-08-25
 tier: 0
 ---
 
 # Release Policy
 
-The TRQP Assurance Hub is now managed as the adoption front door for the Operational Trust Stack. Releases should demonstrate usable assurance value, not routine activity.
+The TRQP Assurance Hub is the adoption front door and coordinated-release authority for the TRQP Operational Trust Stack. Releases must demonstrate usable assurance value, not routine activity.
 
 ## Release classes
 
 | Class | Allowed when | Example |
 |---|---|---|
-| Patch | Security fix, broken CI, broken internal link, schema regression, incorrect release metadata | `v1.8.1` |
-| Minor | New adopter-facing capability with tests, documentation, and evidence impact | `v1.9.0` |
-| Maturity | Coordinated cross-repo improvement across Hub, CTS, and TSPP | Operational Trust Stack maturity release |
+| Patch | Security fix, broken CI, broken internal link, schema regression, incorrect release metadata | `v1.11.1` |
+| Minor | New adopter-facing Hub capability with tests, documentation, and evidence impact | `v1.12.0` |
+| Coordinated Stack | A validated Hub/CTS/TSPP compatibility tuple provides meaningful adopter value or a capability/compatibility change makes a new tuple necessary | `TRQP Stack 2026.1 — Coconut` |
 | No release | Typo, prose polish, non-substantive link rearrangement, exploratory notes | Batch into next milestone |
+
+Component releases retain independent semantic versioning. A component release does not automatically cause a coordinated Stack release.
+
+## Coordinated Stack cadence
+
+The target cadence is approximately monthly when meaningful capability has accumulated. A coordinated release may be cut earlier when a capability, compatibility, security, evidence, or authority change makes a newly validated tuple materially necessary for adopters.
+
+The release decision is capability-driven rather than calendar-driven: a month may pass without a Stack release when there is no meaningful new adopter contract to publish.
+
+## Coordinated Stack naming
+
+Each coordinated Stack release receives:
+
+- a stable machine identity of the form `trqp-stack-YYYY.N`;
+- a human-facing title of the form `TRQP Stack YYYY.N — <codename>`; and
+- a randomly selected codename from the Wikipedia **List of Indian state trees**.
+
+The codename is descriptive release identity only and carries no protocol, assurance-level, or authority semantics. The selected common and scientific names are recorded in the immutable Stack manifest so release naming remains auditable.
 
 ## Required release evidence
 
-Every release must provide:
+Every Hub component release must provide:
 
-- A compatibility tuple for Hub, CTS, and TSPP.
-- Validation commands and outcomes in `docs/release-validation.md` or the release note.
-- Documentation impact summary.
-- Evidence impact summary covering produced, consumed, or validated artifacts.
-- Adoption impact summary for at least one role: implementer, assessor, operator, relying party, or governance steward.
+- a compatibility tuple for Hub, CTS, and TSPP;
+- validation commands and outcomes in `docs/release-validation.md` or the release note;
+- a documentation impact summary;
+- an evidence impact summary covering produced, consumed, or validated artifacts; and
+- an adoption impact summary for at least one role: implementer, assessor, operator, relying party, or governance steward.
+
+Every coordinated Stack release must additionally provide:
+
+- a machine-readable immutable Stack manifest;
+- exact component tags and commit SHAs;
+- pinned TSMM/TIS authority versions;
+- a successful `stack-release-eligibility` workflow on the merged release baseline;
+- the workflow run identifier and candidate evidence artifact digest;
+- a clean-room bootstrap result;
+- deterministic CTS replay evidence;
+- whole-stack semantic replay equivalence;
+- fail-closed negative-case evidence;
+- an executable adopter walkthrough; and
+- synchronized adopter-facing documentation across the Hub, CTS, and TSPP entry points.
 
 ## Release blockers
 
 A release must not be cut when:
 
-- Required validation commands fail.
-- README version metadata does not match `VERSION`.
-- Cross-repo compatibility references are inconsistent.
-- A schema, example, or manifest changes without documentation.
-- New assurance claims are prose-only and not tied to machine-verifiable evidence.
+- required validation commands fail;
+- the decisive coordinated-release workflow is missing or not green for a Stack release;
+- README version or compatibility metadata is inconsistent with the declared component releases;
+- cross-repository compatibility references disagree;
+- a schema, example, manifest, or producer contract changes without corresponding documentation;
+- new assurance claims are prose-only and not tied to machine-verifiable evidence; or
+- the release record cannot identify the authority, scope, provenance, evidence, and invalidation conditions behind its claims.
+
+## Authority and supersession
+
+The Hub may declare that a particular component tuple has passed coordinated integration and assurance gates. This does not transfer TSPP control authority, CTS conformance/replay authority, TSMM semantic authority, TIS schema/portfolio authority, or upstream TRQP specification authority to the Hub.
+
+A coordinated release is immutable historical evidence. When compatibility or assurance conditions change, publish a new Stack release or explicitly supersede the prior release; do not rewrite the historical tuple.

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -6,21 +6,23 @@ nav_exclude: true
 
 # Compatibility Matrix
 
-This matrix identifies coordinated release sets for the TRQP Operational Trust Stack. Operators SHOULD use a supported release set unless they have an explicit compatibility exception.
+This matrix identifies coordinated release sets for the TRQP Operational Trust Stack. Operators SHOULD use a validated or supported release set unless they have an explicit compatibility exception.
 
-| Assurance Hub | Conformance Suite | TRQP-TSPP | Status | Notes |
-|---|---:|---:|---|---|
-| v1.11.0 | v1.8.0 | v0.15.0 | supported | Deterministic Conformance Evidence release. Hub consumes CTS replay-determinism evidence, preserves policy identity and semantic hashes, and fails closed on missing/invalid determinism evidence. |
-| v1.9.0 | v1.6.0 | v0.14.0 | supported | End-to-End Assurance Execution and Evidence Chain with authentic producer evidence, canonical compatibility, traceability, and fail-closed identity validation. |
-| v1.8.0 | v1.5.0 | v0.13.0 | supported | Operational Trust Stack Maturity Release. Adds release governance, validation evidence, adoption packaging, and high-value commit discipline while retaining the Runtime Assurance Contract Pack. |
-| v1.7.0 | v1.4.0 | v0.12.0 | maintenance | Runtime Assurance Contract Pack. Aligns Hub, CTS, and TSPP with TSMM v0.21.0 semantics and TIS v0.10.0 executable artifact contracts for authority, evidence, decision, registry publication, and lifecycle/status evidence. |
-| v1.6.1 | v1.3.1 | v0.11.1 | supported | Operational Trust Stack: Public Assurance and Adoption Readiness. Adds public assurance summaries, scenario profiles, interop evidence matrices, relying-party controls, and adoption packs. |
-| v1.5.0 | v1.2.1 | v0.10.1 | supported | Release Set C: fail-closed CAM identity validation, checked-in operational stack bundle validation, refreshed cross-repo output contract. |
-| v1.4.0 | v1.2.0 | v0.10.0 | supported | Release Set B: AL1/AL2 MVBs, audit guides, adopter template, schema contract, SCI controls, decision tree, crosswalk. |
-| v1.3.1 | v1.1.0 | v0.9.0 | maintenance | Release Set A: deterministic replay, fixture-pinned runs, posture metrics, dry-run. |
-| v1.2.0 | v1.0.0 | v0.8.0 | legacy | Operational Trust Stack stabilization baseline. |
-| v1.1.0 | v0.9.1 | v0.7.1 | legacy | Combined-assurance smoke workflow and machine-readable assurance profiles. |
+| Stack release | Assurance Hub | Conformance Suite | TRQP-TSPP | Status | Notes |
+|---|---:|---:|---:|---|---|
+| **TRQP Stack 2026.1 — Coconut** | **v1.11.0** | **v1.8.0** | **v0.15.0** | **validated** | First formal adopter-facing coordinated release. Passed immutable tuple resolution, clean bootstrap, component evidence generation, deterministic CTS replay, combined assurance, fail-closed cases, full-stack semantic replay equivalence, provenance/integrity checks, and executable walkthrough. TSMM v0.24.0; TIS v0.14.1. |
+| pre-Stack coordinated set | v1.9.0 | v1.6.0 | v0.14.0 | supported | End-to-End Assurance Execution and Evidence Chain with authentic producer evidence, canonical compatibility, traceability, and fail-closed identity validation. |
+| pre-Stack coordinated set | v1.8.0 | v1.5.0 | v0.13.0 | supported | Operational Trust Stack Maturity Release with release governance, validation evidence, adoption packaging, and Runtime Assurance Contract Pack. |
+| pre-Stack coordinated set | v1.7.0 | v1.4.0 | v0.12.0 | maintenance | Runtime Assurance Contract Pack aligned with TSMM v0.21.0 and TIS v0.10.0. |
+| pre-Stack coordinated set | v1.6.1 | v1.3.1 | v0.11.1 | supported | Public Assurance and Adoption Readiness. |
+| pre-Stack coordinated set | v1.5.0 | v1.2.1 | v0.10.1 | supported | Fail-closed CAM identity validation and checked-in operational stack bundle validation. |
+| pre-Stack coordinated set | v1.4.0 | v1.2.0 | v0.10.0 | supported | AL1/AL2 MVBs, audit guides, adopter template, schema contract, SCI controls, decision tree, and crosswalk. |
+| pre-Stack coordinated set | v1.3.1 | v1.1.0 | v0.9.0 | maintenance | Deterministic replay, fixture-pinned runs, posture metrics, and dry-run. |
+| pre-Stack coordinated set | v1.2.0 | v1.0.0 | v0.8.0 | legacy | Operational Trust Stack stabilization baseline. |
+| pre-Stack coordinated set | v1.1.0 | v0.9.1 | v0.7.1 | legacy | Combined-assurance smoke workflow and machine-readable assurance profiles. |
 
 ## Compatibility rule
 
-A Combined Assurance Manifest SHOULD declare the exact release tuple used to produce it. Hub v1.11.0 requires CTS replay-determinism evidence for the `ots-2026-08` release set and records the comparison policy identity, semantic hashes, and reproducibility status in the assurance chain. The Hub does not redefine the CTS policy; policy incompatibility or failed determinism invalidates the integration state.
+A Combined Assurance Manifest SHOULD declare the exact release tuple used to produce it. A formal `TRQP Stack YYYY.N` identity means the tuple has additionally passed the coordinated Stack eligibility gate and has an immutable machine-readable release record under `stack/releases/`.
+
+TRQP Stack 2026.1 requires CTS replay-determinism evidence and records the comparison-policy identity, semantic hashes, reproducibility status, exact component tags/commits, authority pins, decisive workflow run, and eligibility artifact digest. The Hub does not redefine CTS policy or TSPP control semantics; incompatible or failed producer evidence invalidates the integration state.

--- a/stack/examples/canonical-adopter/README.md
+++ b/stack/examples/canonical-adopter/README.md
@@ -1,20 +1,18 @@
+---
+layout: default
+title: "Canonical TRQP stack adopter case"
+nav_exclude: true
+---
+
 # Canonical TRQP stack adopter case
 
-This fixture is the adopter-facing reference target for coordinated TRQP Stack release eligibility. It exists to prove that a new adopter can start from the Assurance Hub, resolve one declared component tuple, run the three repositories, and inspect evidence without independently choosing compatible versions.
+This fixture is the adopter-facing reference target for coordinated TRQP Stack release eligibility. It proves that a new adopter can start from the Assurance Hub, resolve one declared component tuple, run the three repositories, and inspect evidence without independently choosing compatible versions.
 
 ## Decisive test
 
-A stack candidate is eligible only when the following are demonstrated against the declared immutable component tuple:
+A stack candidate is eligible only when the declared immutable component tuple proves release resolution, clean bootstrap, TSPP/CTS execution, deterministic CTS replay, fail-closed Hub composition, provenance/integrity preservation, whole-stack semantic replay equivalence, and an executable walkthrough.
 
-1. the release tuple resolves to the declared tags and commits;
-2. a clean workspace can bootstrap all three components;
-3. TSPP and CTS execute their assurance surfaces;
-4. CTS replay evidence is deterministic under its declared comparison policy;
-5. the Hub consumes correlated evidence and fails closed on invalid inputs;
-6. provenance and integrity are preserved; and
-7. the documented walkthrough remains executable.
-
-The target descriptor in `target.json` is deliberately small: it defines the shared identity and expected cross-stack properties while the authoritative producer fixtures and evidence semantics remain in TSPP and CTS.
+The target descriptor in `target.json` is deliberately small: it defines the shared identity and expected cross-stack properties while authoritative producer fixtures and evidence semantics remain in TSPP and CTS.
 
 ## Run
 
@@ -24,7 +22,7 @@ From the Assurance Hub repository root:
 make stack-release-check
 ```
 
-For an explicit clean-room run:
+For an explicit clean-room release-engineering run:
 
 ```bash
 python tools/stack_validate.py --check-remote
@@ -32,4 +30,6 @@ python tools/stack_bootstrap.py --clean
 python tools/stack_evaluate.py
 ```
 
-These commands produce candidate validation evidence only. They do not publish or imply a coordinated TRQP Stack release.
+These commands generate candidate validation evidence. A coordinated release exists only after the candidate passes the decisive workflow and a maintainer deliberately promotes the validated release record.
+
+TRQP Stack 2026.1 — Coconut is the first release produced through this process.

--- a/stack/releases/2026.1/README.md
+++ b/stack/releases/2026.1/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: "TRQP Stack 2026.1 — Coconut"
+nav_exclude: true
+---
+
 # TRQP Stack 2026.1 — Coconut
 
 **Status:** Validated coordinated release  

--- a/stack/releases/2026.1/README.md
+++ b/stack/releases/2026.1/README.md
@@ -1,0 +1,54 @@
+# TRQP Stack 2026.1 — Coconut
+
+**Status:** Validated coordinated release  
+**Release date:** 2026-08-25  
+**Codename:** Coconut (*Cocos nucifera*)
+
+TRQP Stack 2026.1 is the first coordinated adopter-facing release of the TRQP Operational Trust Stack. It does not replace the independent versioning or authority of TRQP-TSPP, the TRQP Conformance Suite, or the TRQP Assurance Hub. Instead, it declares a specific combination of those independently versioned components that has been exercised together through the Stack Adoption Conformance gate.
+
+## Consumer-facing value
+
+For an adopter, the coordinated release removes the need to determine compatible component versions independently. Start from this release tuple, follow the canonical stack workflow, and obtain a reproducible evidence chain whose provenance identifies the TSPP posture producer, CTS conformance/replay producer, Assurance Hub aggregator, semantic/schema authorities, execution target, run identity, and release-eligibility evidence.
+
+This release is therefore a **compatibility and assurance contract**, not a fourth implementation product.
+
+## Validated tuple
+
+| Layer | Release | Role |
+|---|---:|---|
+| TRQP-TSPP | v0.15.0 | Security/privacy posture and control evidence |
+| TRQP Conformance Suite | v1.8.0 | Protocol conformance and deterministic replay evidence |
+| TRQP Assurance Hub | v1.11.0 | Evidence aggregation and assurance publication |
+| TSMM | v0.24.0 | Semantic authority |
+| TIS | v0.14.1 | Schema and portfolio authority |
+
+The canonical machine-readable record is [`manifest.json`](manifest.json).
+
+## Decisive release evidence
+
+The release tuple passed the `stack-release-eligibility` workflow on the merged Assurance Hub `main` baseline at commit `045ba10ec436ea5d1e9e443894bbbf7bea27472b`.
+
+- Workflow run: `32802386172`
+- Conclusion: `success`
+- Candidate evidence artifact: `trqp-stack-release-candidate-32802386172`
+- Artifact digest: `sha256:56bc91f89add53ad1cbf78031e1d2e26d7051e5f4cfe36c95ed48226556d17a8`
+
+The gate validates immutable release resolution, clean bootstrap, canonical evaluation, TSPP evidence, CTS evidence, deterministic CTS replay, combined assurance, run/target correlation, provenance, artifact integrity, fail-closed negative cases, whole-stack semantic replay equivalence, and the executable adopter walkthrough.
+
+## Adoption path
+
+Use the Assurance Hub as the front door. The canonical workflow is documented in [`docs/adoption/stack-quickstart.md`](../../../docs/adoption/stack-quickstart.md). Adopters may then move into TSPP or CTS directly when they need to customize controls, profiles, test behavior, or evidence production.
+
+## Authority boundaries
+
+The coordinated release does not transfer authority between repositories. TSPP remains authoritative for its security/privacy controls and posture computation. CTS remains authoritative for executable conformance and replay-comparison semantics. Assurance Hub is authoritative for compatibility tuple declaration, integration verification, combined assurance, and coordinated release evidence. TSMM and TIS retain their declared semantic and schema/portfolio authority.
+
+## Cadence and naming
+
+Coordinated Stack releases are expected approximately monthly when meaningful capability has accumulated, and earlier when a capability or compatibility change makes a new validated tuple materially useful or necessary. Routine component changes do not automatically cause a Stack release.
+
+Each coordinated Stack release receives a randomly selected codename from the Wikipedia list of Indian state trees. The codename is human-facing release identity only; the machine identity remains `trqp-stack-YYYY.N`.
+
+## Supersession and invalidation
+
+This release remains valid only for the declared tuple and evidence conditions. A future component release, authority-version change, replay-policy incompatibility, missing or invalid evidence, or other declared invalidation condition may require a new coordinated release. Historical release manifests are retained rather than silently rewritten.

--- a/stack/releases/2026.1/manifest.json
+++ b/stack/releases/2026.1/manifest.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0",
+  "stack": {
+    "id": "trqp-stack-2026.1",
+    "name": "Coconut",
+    "scientific_name": "Cocos nucifera",
+    "status": "validated",
+    "release_date": "2026-08-25"
+  },
+  "components": {
+    "tspp": {
+      "repository": "sankarshanmukhopadhyay/TRQP-TSPP",
+      "ref": "v0.15.0",
+      "commit": "55d52bc115af2b878c16519e4c79d62c3ed8caf7"
+    },
+    "cts": {
+      "repository": "sankarshanmukhopadhyay/trqp-conformance-suite",
+      "ref": "v1.8.0",
+      "commit": "024e88dd9739e7656e49f2129ea1df8a15b7482c"
+    },
+    "assurance_hub": {
+      "repository": "sankarshanmukhopadhyay/trqp-assurance-hub",
+      "ref": "v1.11.0",
+      "commit": "cda924bae643b23d624a8eb41d8c41fae93c481b"
+    }
+  },
+  "authorities": {
+    "tsmm": {
+      "repository": "sankarshanmukhopadhyay/trust-systems-meta-model",
+      "ref": "v0.24.0"
+    },
+    "tis": {
+      "repository": "sankarshanmukhopadhyay/trust-infrastructure-schemas",
+      "ref": "v0.14.1"
+    }
+  },
+  "coordinator": {
+    "repository": "sankarshanmukhopadhyay/trqp-assurance-hub",
+    "validated_main_commit": "045ba10ec436ea5d1e9e443894bbbf7bea27472b"
+  },
+  "eligibility_evidence": {
+    "workflow": "stack-release-eligibility",
+    "workflow_run_id": 32802386172,
+    "workflow_conclusion": "success",
+    "artifact_name": "trqp-stack-release-candidate-32802386172",
+    "artifact_digest": "sha256:56bc91f89add53ad1cbf78031e1d2e26d7051e5f4cfe36c95ed48226556d17a8"
+  },
+  "release_gates": [
+    "release-tuple-resolves",
+    "tagged-commits-match",
+    "clean-bootstrap",
+    "canonical-evaluation",
+    "tspp-evidence-valid",
+    "cts-evidence-valid",
+    "cts-replay-deterministic",
+    "combined-assurance-valid",
+    "run-target-correlation",
+    "provenance-complete",
+    "artifact-integrity-valid",
+    "negative-cases-fail-closed",
+    "full-stack-replay-equivalent",
+    "walkthrough-executable"
+  ]
+}


### PR DESCRIPTION
## Summary

Promotes the validated coordinated-release candidate into the first formal TRQP Stack release record and synchronizes adopter-facing governance/documentation.

## Release identity

**TRQP Stack 2026.1 — Coconut** (`Cocos nucifera`).

## Changes
- adds immutable validated release manifest under `stack/releases/2026.1/`;
- records exact TSPP/CTS/Hub tags and commits plus TSMM/TIS authority pins;
- records the successful `stack-release-eligibility` workflow run and evidence artifact digest;
- publishes the consumer-facing purpose and adoption value of coordinated releases;
- updates release governance with monthly-or-capability-triggered cadence and Indian state-tree random naming;
- updates the compatibility matrix and adopter quickstart;
- makes the Hub README the coordinated Stack front door.

## Assurance evidence

Eligibility workflow run `32802386172` completed successfully on merged Hub `main` commit `045ba10ec436ea5d1e9e443894bbbf7bea27472b`.

Candidate evidence artifact digest: `sha256:56bc91f89add53ad1cbf78031e1d2e26d7051e5f4cfe36c95ed48226556d17a8`.

## Authority

This release declares tested interoperability only. TSPP, CTS, TSMM, TIS, and upstream TRQP authorities remain unchanged.

## Companion documentation
- TRQP-TSPP PR #65
- TRQP Conformance Suite PR #30

## Intended next step

After this PR and companion documentation are green and merged, create/publish the coordinated `trqp-stack-2026.1` release record. This PR itself does not create the GitHub release/tag.