### PR TITLE
release(stack): publish TRQP Stack 2026.1 Coconut

### DIFF
--- a/.github/workflows/publish-coordinated-stack-release.yml
+++ b/.github/workflows/publish-coordinated-stack-release.yml
@@ -1,0 +1,166 @@
+name: publish-coordinated-stack-release
+
+on:
+  workflow_run:
+    workflows: ["stack-release-eligibility"]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout validated main commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Locate pending coordinated release
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t pending < <(find stack/releases -mindepth 2 -maxdepth 2 -name publication.json -print | sort | while read -r file; do
+            python - "$file" <<'PY'
+          import json, sys
+          p = sys.argv[1]
+          data = json.load(open(p, encoding='utf-8'))
+          if data.get('status') == 'pending-publication':
+              print(p)
+          PY
+          done)
+          if [ "${#pending[@]}" -eq 0 ]; then
+            echo "No pending coordinated release."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${#pending[@]}" -ne 1 ]; then
+            echo "Expected exactly one pending coordinated release; found ${#pending[@]}." >&2
+            printf '%s\n' "${pending[@]}" >&2
+            exit 1
+          fi
+          file="${pending[0]}"
+          dir="$(dirname "$file")"
+          python - "$file" "$GITHUB_OUTPUT" <<'PY'
+          import json, sys
+          p, out = sys.argv[1:]
+          data = json.load(open(p, encoding='utf-8'))
+          required = ['release_id','tag','title','release_directory','recorded_eligibility_run_id','recorded_eligibility_artifact','recorded_eligibility_artifact_digest']
+          missing = [k for k in required if not data.get(k)]
+          if missing:
+              raise SystemExit(f"publication record missing: {', '.join(missing)}")
+          if data['release_directory'] != p.rsplit('/', 1)[0]:
+              raise SystemExit('publication release_directory does not match file location')
+          with open(out, 'a', encoding='utf-8') as f:
+              f.write('publish=true\n')
+              for key in required:
+                  f.write(f"{key}={data[key]}\n")
+          PY
+
+      - name: Validate immutable release record
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${{ steps.release.outputs.release_directory }}"
+          python - "$dir/manifest.json" "${{ steps.release.outputs.release_id }}" <<'PY'
+          import json, sys
+          manifest_path, expected = sys.argv[1:]
+          data = json.load(open(manifest_path, encoding='utf-8'))
+          if data.get('stack', {}).get('id') != expected:
+              raise SystemExit('manifest release identity mismatch')
+          if data.get('stack', {}).get('status') != 'validated':
+              raise SystemExit('manifest is not validated')
+          if data.get('eligibility_evidence', {}).get('workflow_conclusion') != 'success':
+              raise SystemExit('manifest does not record successful eligibility evidence')
+          PY
+          python tools/stack_validate.py --check-remote
+
+      - name: Verify recorded eligibility evidence
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_id="${{ steps.release.outputs.recorded_eligibility_run_id }}"
+          artifact_name="${{ steps.release.outputs.recorded_eligibility_artifact }}"
+          expected_digest="${{ steps.release.outputs.recorded_eligibility_artifact_digest }}"
+          run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+          conclusion="$(python -c 'import json,sys; print(json.load(sys.stdin)["conclusion"])' <<<"$run_json")"
+          branch="$(python -c 'import json,sys; print(json.load(sys.stdin)["head_branch"])' <<<"$run_json")"
+          if [ "$conclusion" != "success" ] || [ "$branch" != "main" ]; then
+            echo "Recorded eligibility run is not a successful main run." >&2
+            exit 1
+          fi
+          artifacts_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts")"
+          actual_digest="$(python - "$artifact_name" <<'PY' <<<"$artifacts_json"
+          import json, sys
+          name = sys.argv[1]
+          data = json.load(sys.stdin)
+          matches = [a for a in data.get('artifacts', []) if a.get('name') == name and not a.get('expired')]
+          if len(matches) != 1:
+              raise SystemExit(f'expected one unexpired artifact named {name}, found {len(matches)}')
+          print(matches[0].get('digest', ''))
+          PY
+          )"
+          if [ "$actual_digest" != "$expected_digest" ]; then
+            echo "Eligibility artifact digest mismatch." >&2
+            echo "expected: $expected_digest" >&2
+            echo "actual:   $actual_digest" >&2
+            exit 1
+          fi
+
+      - name: Package coordinated release evidence
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_id="${{ steps.release.outputs.recorded_eligibility_run_id }}"
+          artifact_name="${{ steps.release.outputs.recorded_eligibility_artifact }}"
+          rm -rf /tmp/trqp-stack-evidence /tmp/trqp-stack-evidence.zip
+          mkdir -p /tmp/trqp-stack-evidence
+          gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "$artifact_name" --dir /tmp/trqp-stack-evidence
+          (cd /tmp && zip -qr trqp-stack-evidence.zip trqp-stack-evidence)
+
+      - name: Prepare release notes
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${{ steps.release.outputs.release_directory }}"
+          awk 'BEGIN{fm=0; done=0} NR==1 && $0=="---" {fm=1; next} fm && $0=="---" {fm=0; done=1; next} done || !fm {print}' "$dir/RELEASE_NOTES.md" > /tmp/trqp-stack-release-notes.md
+          test -s /tmp/trqp-stack-release-notes.md
+
+      - name: Publish coordinated GitHub release
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag }}"
+          title="${{ steps.release.outputs.title }}"
+          dir="${{ steps.release.outputs.release_directory }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $tag already exists; refusing to overwrite an immutable coordinated release." >&2
+            exit 1
+          fi
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "${{ github.event.workflow_run.head_sha }}" \
+            --title "$title" \
+            --notes-file /tmp/trqp-stack-release-notes.md \
+            --latest=false \
+            "$dir/manifest.json#TRQP Stack release manifest" \
+            "/tmp/trqp-stack-evidence.zip#Validated coordinated-release evidence"

--- a/.github/workflows/publish-coordinated-stack-release.yml
+++ b/.github/workflows/publish-coordinated-stack-release.yml
@@ -46,7 +46,6 @@ jobs:
             exit 1
           fi
           file="${pending[0]}"
-          dir="$(dirname "$file")"
           python - "$file" "$GITHUB_OUTPUT" <<'PY'
           import json, sys
           p, out = sys.argv[1:]
@@ -65,8 +64,6 @@ jobs:
 
       - name: Validate immutable release record
         if: steps.release.outputs.publish == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -102,10 +99,11 @@ jobs:
             exit 1
           fi
           artifacts_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts")"
-          actual_digest="$(python - "$artifact_name" <<'PY' <<<"$artifacts_json"
-          import json, sys
+          export ARTIFACTS_JSON="$artifacts_json"
+          actual_digest="$(python - "$artifact_name" <<'PY'
+          import json, os, sys
           name = sys.argv[1]
-          data = json.load(sys.stdin)
+          data = json.loads(os.environ['ARTIFACTS_JSON'])
           matches = [a for a in data.get('artifacts', []) if a.get('name') == name and not a.get('expired')]
           if len(matches) != 1:
               raise SystemExit(f'expected one unexpired artifact named {name}, found {len(matches)}')

--- a/stack/releases/2026.1/RELEASE_NOTES.md
+++ b/stack/releases/2026.1/RELEASE_NOTES.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: "TRQP Stack 2026.1 — Coconut release notes"
+nav_exclude: true
+---
+
+# TRQP Stack 2026.1 — Coconut
+
+TRQP Stack 2026.1 — **Coconut** (*Cocos nucifera*) is the first formal coordinated adopter-facing release of the TRQP Operational Trust Stack.
+
+A coordinated Stack release is a **compatibility and assurance contract**. It does not replace independent component versioning and does not create a fourth implementation product. Instead, it identifies an exact tuple of independently governed releases that has been exercised together and preserves the evidence supporting that interoperability claim.
+
+## Validated release tuple
+
+| Layer | Release | Role |
+|---|---:|---|
+| TRQP-TSPP | v0.15.0 | Security/privacy posture and control evidence |
+| TRQP Conformance Suite | v1.8.0 | Protocol conformance and deterministic replay evidence |
+| TRQP Assurance Hub | v1.11.0 | Evidence aggregation and assurance publication |
+| TSMM | v0.24.0 | Semantic authority |
+| TIS | v0.14.1 | Schema and portfolio authority |
+
+## Why this matters to adopters
+
+Before coordinated Stack releases, an adopter could understand each repository independently but still needed to determine which versions should be used together. Stack 2026.1 removes that ambiguity.
+
+An adopter can now select one validated tuple, follow the canonical workflow, reproduce the three-repository execution, and obtain an evidence chain that identifies component provenance, semantic/schema authority, run and target identity, CTS replay policy, combined assurance, and invalidation conditions.
+
+## Release assurance
+
+The decisive `stack-release-eligibility` workflow passed on the merged release baseline. The release process validates:
+
+- immutable component tag and commit resolution;
+- clean-room bootstrap;
+- TSPP evidence validity;
+- CTS conformance evidence;
+- deterministic CTS replay under a declared comparison policy;
+- cross-repository run and target correlation;
+- combined-assurance composition;
+- provenance and artifact integrity;
+- fail-closed negative cases;
+- whole-stack semantic replay equivalence; and
+- the executable adopter walkthrough.
+
+The machine-readable release record is `stack/releases/2026.1/manifest.json`.
+
+## Authority boundaries
+
+The coordinated release does not transfer authority. TRQP-TSPP remains authoritative for its controls, posture computation, and producer evidence. The TRQP Conformance Suite remains authoritative for conformance execution and replay-comparison semantics. The Assurance Hub owns compatibility tuple declaration, integration verification, combined assurance, and coordinated release evidence. TSMM and TIS retain their declared semantic and schema/portfolio authority.
+
+## Documentation synchronization
+
+The release process synchronized the adopter-facing entry points in all three repositories so the same tuple, purpose, and authority boundaries are visible from TSPP, CTS, and Assurance Hub documentation.
+
+## Future cadence
+
+Coordinated Stack releases are expected approximately monthly when meaningful capability has accumulated, or earlier when a capability, compatibility, security, evidence, or authority change makes a new validated tuple materially useful or necessary. Component releases continue independently and do not automatically trigger a Stack release.
+
+Each coordinated release receives a randomly selected codename from the Wikipedia list of Indian state trees. The codename is human-facing identity only; the stable machine identity for this release is `trqp-stack-2026.1`.

--- a/stack/releases/2026.1/manifest.json
+++ b/stack/releases/2026.1/manifest.json
@@ -36,14 +36,14 @@
   },
   "coordinator": {
     "repository": "sankarshanmukhopadhyay/trqp-assurance-hub",
-    "validated_main_commit": "045ba10ec436ea5d1e9e443894bbbf7bea27472b"
+    "validated_main_commit": "699bbb808ede7778e1496589b81ba792610f682e"
   },
   "eligibility_evidence": {
     "workflow": "stack-release-eligibility",
-    "workflow_run_id": 32802386172,
+    "workflow_run_id": 32803124966,
     "workflow_conclusion": "success",
-    "artifact_name": "trqp-stack-release-candidate-32802386172",
-    "artifact_digest": "sha256:56bc91f89add53ad1cbf78031e1d2e26d7051e5f4cfe36c95ed48226556d17a8"
+    "artifact_name": "trqp-stack-release-candidate-32803124966",
+    "artifact_digest": "sha256:4928c84a115f8697c952f2e1599648c9ff2ce2fcef2c034cbb1caec2029c545c"
   },
   "release_gates": [
     "release-tuple-resolves",

--- a/stack/releases/2026.1/publication.json
+++ b/stack/releases/2026.1/publication.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "release_id": "trqp-stack-2026.1",
+  "tag": "trqp-stack-2026.1",
+  "title": "TRQP Stack 2026.1 — Coconut",
+  "release_directory": "stack/releases/2026.1",
+  "status": "pending-publication",
+  "recorded_eligibility_run_id": 32803124966,
+  "recorded_eligibility_artifact": "trqp-stack-release-candidate-32803124966",
+  "recorded_eligibility_artifact_digest": "sha256:4928c84a115f8697c952f2e1599648c9ff2ce2fcef2c034cbb1caec2029c545c",
+  "publish_only_after_main_eligibility_success": true
+}


### PR DESCRIPTION
## Summary

Adds the guarded publication step for the first coordinated TRQP Stack release.

## Release

**TRQP Stack 2026.1 — Coconut** (`trqp-stack-2026.1`)

## Changes
- adds publication-grade release notes;
- updates the immutable release manifest to the final validated `main` release baseline and evidence artifact digest;
- declares one pending publication record;
- adds a reusable `workflow_run` publication workflow that only publishes after `stack-release-eligibility` succeeds on `main`;
- verifies the recorded eligibility workflow and artifact digest before publication;
- packages and attaches the validated eligibility evidence;
- creates the GitHub tag/release idempotently and refuses to overwrite an existing coordinated release.

## Guardrails

The publication workflow has `contents: write` only for tag/release creation and `actions: read` for evidence retrieval. It does not reinterpret TSPP, CTS, TSMM, or TIS authority.

## Target release artifacts
- `stack/releases/2026.1/manifest.json`
- `TRQP Stack 2026.1 — Coconut` release notes
- validated coordinated-release evidence archive

## Publication trigger

After this PR is merged, the resulting `main` commit must first pass `stack-release-eligibility`. Only the successful `workflow_run` event may invoke release publication.